### PR TITLE
Ensure model is world readable

### DIFF
--- a/image/arachne.pkr.hcl
+++ b/image/arachne.pkr.hcl
@@ -40,6 +40,12 @@ build {
     source = "../model"
     destination = "/opt/arachne/"
   }
+  provisioner "shell" {
+    inline = [
+      "find /opt/arachne/model -type d -exec chmod 0755 {} \\;",
+      "find /opt/arachne/model -type f -exec chmod 0644 {} \\;"
+    ]
+  }
 
   # Copy the X11 config to prevent display power saving
   provisioner "shell" {


### PR DESCRIPTION
The model has its permissions specifically adjusted here rather than adjusting the whole of `/opt/arachne` as it's expected that at some point files in this location may need execute permissions, so this keeps everything separate for now.

Fixes https://github.com/dp0/arachne/issues/7